### PR TITLE
Update supported Django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,15 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
+    - "3.8"
 
 env:
-    - DJANGO=1.8.13
-    - DJANGO=1.9.6
-    - DJANGO=1.10.8
-    - DJANGO=1.11.16
-    - DJANGO=2.0.9
-    - DJANGO=2.1.2
+    - DJANGO=1.11.27
+    - DJANGO=2.0.13
+    - DJANGO=2.1.15
+    - DJANGO=2.2.9
+    - DJANGO=3.0.2
 
 install:
     - pip install Django==$DJANGO
@@ -29,8 +30,16 @@ after_success: coverage report; coveralls
 matrix:
     exclude:
         - python: "2.7"
-          env: DJANGO=2.0.9
+          env: DJANGO=2.0.13
         - python: "2.7"
-          env: DJANGO=2.1.2
+          env: DJANGO=2.1.15
+        - python: "2.7"
+          env: DJANGO=2.2.9
+        - python: "2.7"
+          env: DJANGO=3.0.2
         - python: "3.4"
-          env: DJANGO=2.1.2
+          env: DJANGO=2.1.15
+        - python: "3.4"
+          env: DJANGO=2.2.9
+        - python: "3.4"
+          env: DJANGO=3.0.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
 
 install:
     - pip install Django==$DJANGO
-    - pip install coverage
-    - pip install python-coveralls==2.9.1 'PyYAML<5.3'
+    # PyYAML pinned to work on Python 3.4
+    - pip install coverage python-coveralls 'PyYAML<5.3'
     - export PYTHONPATH=.
 
 before_script: coverage erase

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 install:
     - pip install Django==$DJANGO
     - pip install coverage==4.5.1
-    - pip install python-coveralls==2.9.1 PyYAML<5.3
+    - pip install python-coveralls==2.9.1 'PyYAML<5.3'
     - export PYTHONPATH=.
 
 before_script: coverage erase

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 
 install:
     - pip install Django==$DJANGO
-    - pip install coverage==4.5.1
+    - pip install 'coverage<5'
     - pip install python-coveralls==2.9.1 'PyYAML<5.3'
     - export PYTHONPATH=.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 
 install:
     - pip install Django==$DJANGO
-    - pip install 'coverage<5'
+    - pip install coverage
     - pip install python-coveralls==2.9.1 'PyYAML<5.3'
     - export PYTHONPATH=.
 
@@ -45,3 +45,5 @@ matrix:
           env: DJANGO=3.0.2
         - python: "3.5"
           env: DJANGO=3.0.2
+        - python: "3.8"
+          env: DJANGO=1.11.27

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 install:
     - pip install Django==$DJANGO
     - pip install coverage==4.5.1
-    - pip install python-coveralls==2.9.1
+    - pip install python-coveralls==2.9.1 PyYAML<5.3
     - export PYTHONPATH=.
 
 before_script: coverage erase
@@ -42,4 +42,6 @@ matrix:
         - python: "3.4"
           env: DJANGO=2.2.9
         - python: "3.4"
+          env: DJANGO=3.0.2
+        - python: "3.5"
           env: DJANGO=3.0.2

--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -26,6 +26,11 @@ You can determine your currently installed version using `pip freeze`:
 
 ---
 
+## Pending
+
+* Stop testing on Django 1.8, 1.9, and 1.10.
+* Test on Django 2.2 and 3.0.
+
 ## 1.0.6
 
 **Released**: 29th December 2018

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ url = 'http://django-vanilla-views.org'
 author = 'Tom Christie'
 author_email = 'tom@tomchristie.com'
 license = 'BSD'
-install_requires = []
+install_requires = [
+    'six',
+]
 
 long_description = """Django's generic class based view implementation is unneccesarily complicated.
 
@@ -87,12 +89,11 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,16 @@
 [tox]
 envlist =
-    dj18-py{27,34,35,36,37},
-    dj19-py{27,34,35,36,37},
-    dj110-py{27,34,35,36,37},
     dj111-py{27,34,35,36,37},
     dj20-py{34,35,36,37},
-    dj21-py{34,35,36,37},
+    dj21-py{35,36,37},
+    dj22-py{35,36,37},
+    dj30-py{36,37,38}
 
 [testenv]
 commands = {envpython} -Wall manage.py test
 deps =
-    dj18: django>=1.8,<1.9
-    dj19: django>=1.9,<1.10
-    dj110: django>=1.10,<1.11
     dj111: django>=1.11,<2.0
     dj20: django>=2.0,<2.1
     dj21: django>=2.1,<2.2
+    dj22: django>=2.2,<3.0
+    dj30: django>=3.0,<3.1

--- a/vanilla/model_views.py
+++ b/vanilla/model_views.py
@@ -1,14 +1,20 @@
 #coding: utf-8
+import django
 from django.core.exceptions import ImproperlyConfigured
 from django.core.paginator import Paginator, InvalidPage
 from django.forms import models as model_forms
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
-from django.utils import six
-from django.utils.translation import ugettext as _
 from django.views.generic import View
 import warnings
+import six
+
+# Avoid RemovedInDjango40Warning on Django 3.0+
+if django.VERSION >= (3, 0):
+    from django.utils.translation import gettext as _
+else:
+    from django.utils.translation import ugettext as _
 
 
 class GenericModelView(View):
@@ -133,7 +139,7 @@ class GenericModelView(View):
             return paginator.page(page_number)
         except InvalidPage as exc:
             msg = 'Invalid page (%s): %s'
-            raise Http404(_(msg % (page_number, six.text_type(exc))))
+            raise Http404(_(msg) % (page_number, six.text_type(exc)))
 
     # Response rendering
 


### PR DESCRIPTION
Fixes #88.

Drop support for old versions 1.8-1.10.

Add support for Django 2.2 and Django 3.0.

The latter drops the internal 'six', but since we still support Python 2 for Django 1.11, we now depend on the separate 'six'.

Also fix the bracketing on the translated Http404 message.