### PR TITLE
docs: Fix simple typo, hierachy -> hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ For example:
 
 To help give you an idea of the relative complexity of `django-vanilla-views` against Django's existing implementations, let's compare the two.
 
-#### Inheritance hierachy, Vanilla style.
+#### Inheritance hierarchy, Vanilla style.
 
 The inheritance hierarchy of the views in `django-vanilla-views` is trivial, making it easy to figure out the control flow in the view.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -138,7 +138,7 @@ For example:
 
 To help give you an idea of the relative complexity of `django-vanilla-views` against Django's existing implementations, let's compare the two.
 
-#### Inheritance hierachy, Vanilla style.
+#### Inheritance hierarchy, Vanilla style.
 
 The inheritance hierarchy of the views in `django-vanilla-views` is trivial, making it easy to figure out the control flow in the view.
 
@@ -146,7 +146,7 @@ The inheritance hierarchy of the views in `django-vanilla-views` is trivial, mak
 
 **Total number of source files**: 1 ([model_views.py][model_views.py])
 
-#### Inheritance hierachy, Django style.
+#### Inheritance hierarchy, Django style.
 
 Here's the corresponding inheritance hiearchy in Django's implementation of `CreateView`.
 


### PR DESCRIPTION
There is a small typo in README.md, docs/index.md.

Should read `hierarchy` rather than `hierachy`.

