### PR TITLE
Drop some Python 2 features

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP',
     ]


### PR DESCRIPTION
Wheels will no longer be universal, and the Python 2 classifier should not be there.

Missed in #92.